### PR TITLE
add simple generic rules

### DIFF
--- a/v1/generic/evidence-exists.yaml
+++ b/v1/generic/evidence-exists.yaml
@@ -1,0 +1,11 @@
+name: required-evidence
+description: "Verify required evidence exists"
+labels:
+  - 3rd-party
+initiatives:
+  - Default
+evidence:
+  signed: true
+  format-type: generic
+  target_type: data
+  predicate_type: http://scribesecurity.com/evidence/generic/v0.1

--- a/v1/generic/evidence-exists.yaml
+++ b/v1/generic/evidence-exists.yaml
@@ -5,7 +5,6 @@ labels:
 initiatives:
   - Default
 evidence:
-  signed: true
   format-type: generic
   target_type: data
   predicate_type: http://scribesecurity.com/evidence/generic/v0.1

--- a/v1/generic/evidence-exists.yaml
+++ b/v1/generic/evidence-exists.yaml
@@ -1,9 +1,9 @@
 name: required-evidence
 description: "Verify required evidence exists"
+
 labels:
   - 3rd-party
-initiatives:
-  - Default
+
 evidence:
   format-type: generic
   target_type: data

--- a/v1/generic/trivy-exists.yaml
+++ b/v1/generic/trivy-exists.yaml
@@ -1,0 +1,11 @@
+name: required-trivy-evidence
+description: "Verify required Trivy evidence exists"
+labels:
+  - 3rd-party
+initiatives:
+  - Default
+evidence:
+  signed: true
+  format-type: generic
+  target_type: data
+  predicate_type: https://aquasecurity.github.io/trivy/v0.42/docs/configuration/reporting/#json

--- a/v1/generic/trivy-exists.yaml
+++ b/v1/generic/trivy-exists.yaml
@@ -5,7 +5,6 @@ labels:
 initiatives:
   - Default
 evidence:
-  signed: true
   format-type: generic
   target_type: data
   predicate_type: https://aquasecurity.github.io/trivy/v0.42/docs/configuration/reporting/#json

--- a/v1/generic/trivy-exists.yaml
+++ b/v1/generic/trivy-exists.yaml
@@ -1,9 +1,9 @@
 name: required-trivy-evidence
 description: "Verify required Trivy evidence exists"
+
 labels:
   - 3rd-party
-initiatives:
-  - Default
+
 evidence:
   format-type: generic
   target_type: data


### PR DESCRIPTION
```
name: "3rd-party full kit"
defaults:
  evidence:
    signed: false
rules:
  # valint evidence <file> --parser trivy
  - name: trivy-scan
    level: error
    uses: generic/trivy-exists@v1

  # valint evidence <file> --parser blackduck
  - name: blackduck-scan
    level: warning
    uses: generic/evidence-exists@v1
    evidence:
      parser: Blackduck

  # valint evidence <file> --parser kics
  - name: kics-scan
    level: warning
    uses: generic/evidence-exists@v1
    evidence:
      parser: KICS

  # valint evidence <file> --parser checkmarxone
  - name: checkmarx-one-scan
    level: warning
    uses: generic/evidence-exists@v1
    evidence:
      parser: CheckmarxOne #CheckmarxOsa, Checkmarx

  # valint evidence <file> --parser netsparker
  - name: netsparker
    level: warning
    uses: generic/evidence-exists@v1
    evidence:
      parser: Netsparker

```