### PR TITLE
Pass public repo

### DIFF
--- a/v1/github/repository/repo-private.rego
+++ b/v1/github/repository/repo-private.rego
@@ -29,7 +29,12 @@ verify = v {
 }
 
 allow {
+	not exception
 	count(violations) == 0
+}
+
+allow {
+	exception
 }
 
 reason = v {

--- a/v1/github/repository/repo-private.rego
+++ b/v1/github/repository/repo-private.rego
@@ -6,6 +6,13 @@ default allow := false
 
 default violations := []
 
+default exception := false
+
+exception := {
+	input.config.args.exception
+}
+
+
 verify = v {
 	v := {
 		"allow": allow,
@@ -26,13 +33,20 @@ allow {
 }
 
 reason = v {
+	not exception
 	allow
 	v := "The repository is private"
 }
 
 reason = v {
+	not exception
 	not allow
 	v := "The repository is not private"
+}
+
+reason = v {
+	exception
+	v := "The rule is set to exception"
 }
 
 # j is now a list in order to make sure duplications are not lost

--- a/v1/github/repository/repo-private.yaml
+++ b/v1/github/repository/repo-private.yaml
@@ -14,3 +14,5 @@ evidence:
     - "asset_type=repository"
 
 with:
+  exception: false
+  # If true - the whole rule is exceptioned but the rule result will appear. defaults to false


### PR DESCRIPTION
An example of an allowed exception: I want the rule to appear, but I want to set it as exception.
@cppvik @houdini91 what do you think? 

I think we should consider such a valint feature to bypass a whole rule, and for each rule to decide if we want some specific exceptions. Anyways I implemented this and it serves the dogfooding for now.